### PR TITLE
Don't redefine LITTLE_ENDIAN macro

### DIFF
--- a/src/DFRobot_BMX160.h
+++ b/src/DFRobot_BMX160.h
@@ -13,7 +13,9 @@
 #include <Wire.h>
 #include <SPI.h>
 
+#ifndef LITTLE_ENDIAN
 #define LITTLE_ENDIAN 1
+#endif
 
 /** Mask definitions */
 #define BMX160_ACCEL_BW_MASK 0x70


### PR DESCRIPTION
Another lib has this macro defined already, so adding a guard is helpful to squash compilation warnings.